### PR TITLE
Make sure custom titles are used

### DIFF
--- a/rangefilter/filters.py
+++ b/rangefilter/filters.py
@@ -86,11 +86,12 @@ class DateRangeFilter(admin.filters.FieldListFilter):
         )
         self.request = request
         self.model_admin = model_admin
-        self.form = self.get_form(request)
 
         custom_title = self._get_custom_title(request, model_admin, field_path)
         if custom_title:
             self.title = custom_title
+
+        self.form = self.get_form(request)
 
     @staticmethod
     def get_timezone(_request):
@@ -303,11 +304,12 @@ class NumericRangeFilter(admin.filters.FieldListFilter):
         )
         self.request = request
         self.model_admin = model_admin
-        self.form = self.get_form(request)
 
         custom_title = self._get_custom_title(request, model_admin, field_path)
         if custom_title:
             self.title = custom_title
+
+        self.form = self.get_form(request)
 
     def get_template(self):
         return "rangefilter/numeric_filter.html"


### PR DESCRIPTION
There's an issue on `master` where setting a custom title as documented does not work:

```python
# this is ignored
def get_rangefilter_created_at_title(self, request, field_path):
  return 'custom title'
```

After a bit of digging, the issue appears to occur because the form in `DateRangeFilter` and `NumericRangeFilter` is instantiated before the custom title is checked: https://github.com/EricOuma/django-jazzmin-admin-rangefilter/blob/bbd47f9f1c6260705d97218df442640a900a991c/rangefilter/filters.py#L89-L93

More specifically, `get_form` calls `_get_form_class`, which then calls `_get_form_fields` and instantiates the form widgets. If title isn't set first, it never gets used here: https://github.com/EricOuma/django-jazzmin-admin-rangefilter/blob/bbd47f9f1c6260705d97218df442640a900a991c/rangefilter/filters.py#L212-L214

This PR just checks for custom titles before calling `get_form`. I validated this fix worked by installing the forked repo directly.